### PR TITLE
wowdump: automatic listfile download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,9 @@ python_files = [ "test_*.py", "check_*.py", "example_*.py" ]
 testpaths = [ "tests" ]
 
 required_plugins = [
-    "pytest-html>=3.1",
+    "pytest-html >=3.1",
     "pytest-cov >=2.12",
-    "pytest-order >= 1.0",
+    "pytest-order >=1.0",
 ]
 
 
@@ -125,8 +125,10 @@ deps =
     pytest-html >=3.1
     pytest-cov >=2.12
     pytest-order >=1.0
+    requests >=2.25.0
     kaitaistruct==0.9
     ppretty>=1.3
+    responses>=0.16.0
 
 commands = {posargs:pytest}
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,11 +24,11 @@ package_dir =
     = .
 
 # packages = wowdump
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     kaitaistruct==0.9
     ppretty>=1.3
-    # pysqlite3~=0.4.0
+    requests>=2.25.0
 
 # [options.extras_require]
 # dev =
@@ -39,6 +39,7 @@ install_requires =
 #	pytest-mock~=3.5.1
 #	pytest~=6.2.2
 #	tox~=3.21.3
+#	responses~=0.16.0
 
 [options.packages.find]
     # I don't really want to put my one package in another subdir so that

--- a/tests/test_listfile_download.py
+++ b/tests/test_listfile_download.py
@@ -1,0 +1,147 @@
+# type: ignore
+import logging
+
+import wowdump
+
+import pytest
+# import requests
+import responses
+
+# FIXME: Not sure why I can't pull this in from main wowdump
+DEFAULT_LISTFILE_URL: str = "https://wow.tools/casc/listfile/download/csv/unverified"
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+def test_download_200(tmp_path, mocked_responses, capsys, extra):
+    mocked_responses.add(
+        responses.GET, DEFAULT_LISTFILE_URL,
+        body='12345;DEFAULT_LISTFILE_URL DOWNLOAD', status=200,
+        content_type='application/json')
+
+    listfile = tmp_path / "listfile.csv"
+    ret = wowdump.main([
+        "--listfile", str(listfile),
+        "--download-listfile",
+    ])
+    assert ret == 0, f"wowdump exited with non-zero exit code ({ret})"
+
+    captured = capsys.readouterr()
+    assert "NOTICE: downloading new listfile" in captured.err
+    assert listfile.read_text() == "12345;DEFAULT_LISTFILE_URL DOWNLOAD"
+
+
+def test_download_404(tmp_path, mocked_responses, capsys, extra):
+    mocked_responses.add(
+        responses.GET, DEFAULT_LISTFILE_URL,
+        body='DEFAULT_LISTFILE_URL ERROR', status=404)
+
+    listfile = tmp_path / "listfile.csv"
+    ret = wowdump.main([
+        "--listfile", str(listfile),
+        "--download-listfile",
+    ])
+    assert ret == 69, f"wowdump exited with improper exit code (should be 69 (os.EX_UNAVAILABLE)), was {ret}"
+
+    captured = capsys.readouterr()
+    assert "NOTICE: downloading new listfile" in captured.err
+    assert "ERROR: couldn't download listfile: 404 Not Found" in captured.err
+
+
+def test_download_500(tmp_path, mocked_responses, capsys, extra):
+    mocked_responses.add(
+        responses.GET, DEFAULT_LISTFILE_URL,
+        body='DEFAULT_LISTFILE_URL ERROR', status=500)
+
+    listfile = tmp_path / "listfile.csv"
+    ret = wowdump.main([
+        "--listfile", str(listfile),
+        "--download-listfile",
+    ])
+    assert ret == 69, f"wowdump exited with improper exit code (should be 69 (os.EX_UNAVAILABLE)), was {ret}"
+
+    captured = capsys.readouterr()
+    assert "NOTICE: downloading new listfile" in captured.err
+    assert "ERROR: couldn't download listfile: 500 Internal Server Error" in captured.err
+
+
+def test_download_alternate_url(tmp_path, mocked_responses, capsys, extra):
+    alternate_url = "http://example.com/listfile.csv"
+    mocked_responses.add(
+        responses.GET, alternate_url,
+        body='12345;ALTERNATE_URL DOWNLOAD', status=200)
+
+    listfile = tmp_path / "listfile.csv"
+    ret = wowdump.main([
+        "--listfile", str(listfile),
+        "--listfile-url", alternate_url,
+        "--download-listfile",
+    ])
+    assert ret == 0, f"wowdump exited with non-zero exit code ({ret})"
+
+    captured = capsys.readouterr()
+    assert "NOTICE: downloading new listfile" in captured.err
+    assert listfile.read_text() == "12345;ALTERNATE_URL DOWNLOAD"
+
+
+# test the behavior of --download-listfile when the listfile is and
+# isn't present
+def test_download_force_flag(tmp_path, mocked_responses, capsys, caplog, extra):
+    mocked_responses.add(
+        responses.GET, DEFAULT_LISTFILE_URL,
+        body='12345;DEFAULT_LISTFILE_URL DOWNLOAD', status=200,
+        content_type='application/json')
+
+    listfile = tmp_path / "listfile.csv"
+    wowdump.set_default_listfile(listfile)
+
+    # If it doesn't exist and we've said we don't want to download it,
+    # make sure we don't download it
+    assert not listfile.exists(), "our fresh tmpdir already has a listfile?!"
+    ret = wowdump.main([
+        # "--listfile", str(listfile),
+        "--no-download-listfile",
+    ])
+    assert ret == 0, f"wowdump exited with non-zero exit code ({ret})"
+
+    assert ("csvcache", logging.WARNING,
+            str(listfile) + " does not exist, not resolving fileids") in caplog.record_tuples
+
+    assert not listfile.exists(), "downloaded listfile when we shouldn't have"
+
+
+    # If it doesn't exist otherwise, we should try to download it
+    ret = wowdump.main([
+        # "--listfile", str(listfile),
+    ])
+    assert ret == 0, f"wowdump exited with non-zero exit code ({ret})"
+
+    captured = capsys.readouterr()
+    assert "NOTICE: downloading new listfile" in captured.err
+    assert listfile.read_text() == "12345;DEFAULT_LISTFILE_URL DOWNLOAD"
+
+
+    # it exists now, make sure we don't try to download it again
+    # If it doesn't exist otherwise, we should try to download it
+    ret = wowdump.main([
+        # "--listfile", str(listfile),
+    ])
+    assert ret == 0, f"wowdump exited with non-zero exit code ({ret})"
+
+    captured = capsys.readouterr()
+    assert "WARNING: listfile does not exist" not in captured.err
+    assert "NOTICE: downloading new listfile" not in captured.err
+
+
+    # it exists, but make sure we _do_ try to download it if we
+    # explicitly request it
+    ret = wowdump.main([
+        # "--listfile", str(listfile),
+        "--download-listfile",
+    ])
+    assert ret == 0, f"wowdump exited with non-zero exit code ({ret})"
+
+    captured = capsys.readouterr()
+    assert "NOTICE: downloading new listfile" in captured.err

--- a/tests/test_walk_resolve.py
+++ b/tests/test_walk_resolve.py
@@ -1,3 +1,4 @@
+# type: ignore
 import logging
 import os
 from pathlib import Path

--- a/wowdump/__init__.py
+++ b/wowdump/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa
-from .wowdump import main
+# FIXME: the listfile stuff here is painful
+from .wowdump import get_default_listfile, main, set_default_listfile

--- a/wowdump/commands/__init__.py
+++ b/wowdump/commands/__init__.py
@@ -1,4 +1,9 @@
 # flake8: noqa
+import argparse
+from typing import Callable
+
 from .bulkwalk import cmd_bulkwalk
 from .pathwalk import cmd_pathwalk
 from .simple import cmd_final, cmd_json, cmd_raw, cmd_report
+
+WowdumpCommand = Callable[[argparse.Namespace], int]

--- a/wowdump/commands/bulkwalk.py
+++ b/wowdump/commands/bulkwalk.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from kaitaistruct import KaitaiStructError
 
-from .. import csvcache, filetypes
+from .. import filetypes
 from ..dumputil import DataOutput, fileparse, get_contenthash
 from ..filters import check_filtered
 from .pathwalk import pathwalk
@@ -116,12 +116,6 @@ def cmd_bulkwalk(args):
     if not indir.exists() or not indir.is_dir():
         print(f"ERROR: doesn't exist or isn't a directory: {indir}")
         return 65  # os.EX_DATAERR
-
-    # Path(args.listfile).unlink(missing_ok=True)
-    if args.resolve:
-        csvcache.init("listfile", args.listfile)
-    else:
-        csvcache.init("listfile", None)
 
     supported = filetypes.get_supported()
 

--- a/wowdump/commands/pathwalk.py
+++ b/wowdump/commands/pathwalk.py
@@ -1,17 +1,9 @@
-from .. import csvcache
 from ..dumputil import DataOutput, fileparse, get_contenthash
 from ..filters import check_filtered
 from ..pathwalk import pathwalk
 
 
 def cmd_pathwalk(args):
-    # FIXME: Should we just blanket-initialize this in main()?
-    # Path(args.listfile).unlink(missing_ok=True)
-    if args.resolve:
-        csvcache.init("listfile", args.listfile)
-    else:
-        csvcache.init("listfile", None)
-
     # FIXME: better error handling (or error handling at all)
     with DataOutput(args.output) as out:
         target = fileparse(args.file)

--- a/wowdump/csvcache.py
+++ b/wowdump/csvcache.py
@@ -28,6 +28,7 @@ class ListfileCache(object):
 
         if listfile is None:
             self.nocache = True
+            self.listfile = None
             log.debug("not resolving, not initializing cache")
             return
 
@@ -73,6 +74,7 @@ class ListfileCache(object):
 
         if not self.__populate_needed():
             if not force:
+                # print(self.cachefile)
                 self.db = sqlite3.connect(self.cachefile)
                 return
 
@@ -154,12 +156,15 @@ def init(cachename: str, file: Optional[Union[str, Path]]) -> ListfileCache:
     # If it already exists, call populate() to reload things if it makes sense
     if cachename in caches:
         c = caches[cachename]
+        # import sys
+        # print(ppretty(c), file=sys.stderr)
 
         if c.nocache and file is None:
             log.debug(f"reinitializing nocache cache {cachename}, doing nothing")
             return c
 
-        if getattr(c, "listfile", None) == file:
+        lfile = getattr(c, "listfile", None)
+        if not c.nocache and lfile is not None and lfile == file:
             log.debug(f"reinitializing existing cache {cachename} from {file}")
             c.populate()
             return c


### PR DESCRIPTION
Automatic listfile download to ~/.wowdump_listfile.csv if it doesn't exist.
Adds options --[no-]download-listfile (force download if a current listfile
exists, or stop download from happening even if nonexistant), and
--listfile-url (hidden; specify download URL for the listfile)